### PR TITLE
Fix alignment issue when using spaces with the separator.

### DIFF
--- a/protocol
+++ b/protocol
@@ -131,7 +131,7 @@ class Protocol():
                 raise
             except:
                 raise ProtocolException("FATAL: Invalid field_list specification (%s)" %spec)
-            self.field_list.append({"text":text, "len":bits})
+            self.field_list.append({"text":text.strip(), "len":bits})
 
         # Parse options
         if opts is not None:


### PR DESCRIPTION
For example:

./protocol  "pos_x:32, pos_y:32, pos_z:32"

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                             pos_x                             |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                              pos_y                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                              pos_z                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```